### PR TITLE
Fixed to preinstall with docker-phpenv, to eliminate conchoid/docker-…

### DIFF
--- a/7.4-stretch/Dockerfile
+++ b/7.4-stretch/Dockerfile
@@ -1,21 +1,59 @@
-FROM debian:stretch
+FROM debian:stretch AS build-base
+RUN apt-get update && apt-get install -y \
+    bzip2 curl gcc m4 make tar \
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
 
+FROM build-base AS build-libiconv
+RUN curl -SL http://ftp.gnu.org/pub/gnu/libiconv/libiconv-1.15.tar.gz | tar -xz -C ~/ \
+    && ~/libiconv-1.15/configure --prefix=/usr/bin \
+    && make && make install
+
+# bison 2.x is required for building php5.x
+FROM build-base AS build-bison
+RUN WORK_DIR="/tmp/bison/" \
+    BISON_VERSION="2.6.4" \
+    && mkdir -p ${WORK_DIR}/downloads ${WORK_DIR}/src \
+    && curl -SL -o ${WORK_DIR}/downloads/bison-${BISON_VERSION}.tar.gz http://ftp.gnu.org/gnu/bison/bison-${BISON_VERSION}.tar.gz \
+    && tar -zxf ${WORK_DIR}/downloads/bison-${BISON_VERSION}.tar.gz -C ${WORK_DIR}/src \
+    && cd ${WORK_DIR}/src/bison-${BISON_VERSION}/ \
+    && ./configure --prefix=/usr/local/lib/bison \
+    && make && make install
+
+FROM build-base
 # Preset locale to en_US.UTF-8
 # https://docs.docker.com/samples/library/debian/#locales
-RUN apt-get update && apt-get install -y locales && apt-get clean && rm -rf /var/lib/apt/lists/* \
+RUN apt-get update && apt-get install -y \
+    apt-transport-https \
+    ca-certificates \
+    git \
+    locales \
+    subversion \
+    && apt-get clean && rm -rf /var/lib/apt/lists/* \
     && localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8
 ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US:en
 ENV LC_ALL en_US.UTF-8
 
-RUN apt-get update && apt-get install -y \
-       wget curl git subversion apt-transport-https ca-certificates \
-   && apt-get clean && rm -rf /var/lib/apt/lists/*
+COPY --from=build-libiconv /usr/bin/lib/ /usr/bin/lib
+ENV LD_PRELOAD /usr/bin/lib/preloadable_libiconv.so
+
+COPY --from=build-bison /usr/local/lib/bison /usr/local/lib/bison
+RUN ln -s /usr/local/lib/bison/bin/bison /usr/local/bin/bison
+
+# buffio.h is deprecated but needed for building php prior to 7.2.
+RUN curl -o /usr/include/buffio.h https://raw.githubusercontent.com/htacg/tidy-html5/5.6.0/include/buffio.h
+
+# easy.h should be in <curl-dir>/include/curl/
+RUN ln -s /usr/include/x86_64-linux-gnu/curl /usr/include
+
+ENV CONCHOID_DOCKER_PHPENV_HOME /conchoid/docker-phpenv
+COPY . ${CONCHOID_DOCKER_PHPENV_HOME}
+RUN ${CONCHOID_DOCKER_PHPENV_HOME}/install-builddeps.sh
 
 # Installing PHP 7.4
 # https://packages.sury.xyz/php/README.txt
 RUN DPKG_NAME="php7.4" \
-    && wget -O /etc/apt/trusted.gpg.d/php.gpg https://packages.sury.org/php/apt.gpg \
+    && curl -SL -o /etc/apt/trusted.gpg.d/php.gpg https://packages.sury.org/php/apt.gpg \
     && sh -c 'echo "deb https://packages.sury.org/php/ stretch main" > /etc/apt/sources.list.d/php.list'\
     && apt-get update \
     && PHP_DPKG_VERSION=$(apt-cache show "${DPKG_NAME}" | grep -e "^Version: " | cut -d" " -f2) \
@@ -27,18 +65,6 @@ RUN DPKG_NAME="php7.4" \
         "${DPKG_NAME}-dev=${PHP_DPKG_VERSION}" \
    && rm -f /etc/apt/sources.list.d/php.list \
    && apt-get clean && rm -rf /var/lib/apt/lists/*
-
-ENV CONCHOID_DOCKER_PHPENV_HOME /conchoid/docker-phpenv
-COPY . ${CONCHOID_DOCKER_PHPENV_HOME}
-RUN ${CONCHOID_DOCKER_PHPENV_HOME}/install-builddeps.sh
-
-RUN curl -SL http://ftp.gnu.org/pub/gnu/libiconv/libiconv-1.15.tar.gz | tar -xz -C ~/ \
-	&& rm /usr/bin/iconv \
-	&& mv ~/libiconv-1.15 ~/libiconv \
-	&& ~/libiconv/configure --prefix=/usr/bin \
-	&& make && make install
-
-ENV LD_PRELOAD /usr/bin/lib/preloadable_libiconv.so
 
 # Installing Composer.
 # Refer to https://getcomposer.org/doc/faqs/how-to-install-composer-programmatically.md
@@ -72,3 +98,33 @@ RUN PHPENV_VERSION=9b7e4e1c0083c46be69f4c6d063f78c18654aad1 \
     # https://github.com/madumlao/phpenv/blob/085261129f7231fcd3b34401ad4af84b21df62eb/libexec/phpenv-global#L45
     && touch ${PHPENV_ROOT}/bin/apxs && chmod +x ${PHPENV_ROOT}/bin/apxs
 
+ENV PHP_CONFIGURE_OPTS "--disable-fpm --disable-cgi"
+ENV PHP_AUTOCONF /usr/bin/autoconf
+
+# Install all latest versions excludes older than one year since EOL.
+# https://www.php.net/supported-versions.php
+ENV PREINSTALLED_VERSIONS "\
+7.1.33\n\
+7.2.34\n\
+7.3.24\n\
+7.4.12"
+
+RUN phpenv global system \
+    && system_php_ver=$(php -v | head -1 | sed -e "s/^PHP \([0-9.]*\).*$/\1/") \
+    && version_bin_dir="${PHPENV_ROOT}/versions/${system_php_ver}/bin" \
+    && mkdir -p "${version_bin_dir}" \
+    && cp "$(phpenv which php)" "${version_bin_dir}" \
+    && cp "$(phpenv which php-config)" "${version_bin_dir}" \
+    && cp "$(phpenv which phar)" "${version_bin_dir}" \
+    && cp "$(phpenv which phar.phar)" "${version_bin_dir}" \
+    && export CONFIGURE_OPTS="${PHP_CONFIGURE_OPTS}" \
+    && export CFLAGS="${PHP_CFLAGS}" \
+    && echo "${PREINSTALLED_VERSIONS}" | while read version;do \
+        if [ ! -e "${PHPENV_ROOT}/versions/${version}" ];then \
+            phpenv install $version \
+            && phpenv global $version \
+            && php --ini | grep 'Loaded Configuration File' | awk -F':' '{ print $2 }' | xargs -i /bin/sh -c 'echo "[Date]\ndate.timezone = UTC" >> {}' \
+            && [ $(php --ini 2>&1 >/dev/null | wc -l) = "0" ] || exit 1 \
+        ; fi \
+    ; done \
+    && phpenv global system

--- a/7.4-stretch/install-builddeps.sh
+++ b/7.4-stretch/install-builddeps.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 set -eux
-
+# php install build deps
 apt-get update && apt-get -y --allow-downgrades install  \
   autoconf \
   coreutils \
@@ -9,7 +9,6 @@ apt-get update && apt-get -y --allow-downgrades install  \
   dpkg-dev \
   file \
   g++ \
-  gcc \
   gnupg \
   libbz2-dev \
   libcurl3 \
@@ -24,12 +23,10 @@ apt-get update && apt-get -y --allow-downgrades install  \
   libreadline-dev \
   libsqlite3-dev \
   libtidy-dev \
-  libxml2="2.9.4+dfsg1-2.2+deb9u2" \
   libxml2-dev="2.9.4+dfsg1-2.2+deb9u2" \
+  libxml2="2.9.4+dfsg1-2.2+deb9u2" \
   libxslt1-dev \
   libzip-dev \
-  m4 \
-  make \
   mercurial \
   patch \
   pkgconf \
@@ -37,8 +34,7 @@ apt-get update && apt-get -y --allow-downgrades install  \
   python-dev \
   re2c \
   sqlite3 \
-  tar \
-  tidy 
+  tidy
 
 # openssl1.0.x and related libssl packages are required for installing php5.x by phpenv.
 echo "deb http://ftp.br.debian.org/debian/ jessie main" > /etc/apt/sources.list.d/jessie.list 
@@ -50,21 +46,3 @@ rm -f /etc/apt/sources.list.d/jessie.list
 
 apt-get clean
 rm -rf /var/lib/apt/lists/*
-
-# buffio.h is deprecated but needed for building php prior to 7.2.
-curl -o /usr/include/buffio.h https://raw.githubusercontent.com/htacg/tidy-html5/5.6.0/include/buffio.h
-
-# bison 2.x is required for building php5.x
-WORK_DIR="/tmp/bison/"
-BISON_VERSION="2.6.4"
-mkdir -p ${WORK_DIR}/downloads ${WORK_DIR}/src
-wget http://ftp.gnu.org/gnu/bison/bison-${BISON_VERSION}.tar.gz -P ${WORK_DIR}/downloads/
-tar -zxf ${WORK_DIR}/downloads/bison-${BISON_VERSION}.tar.gz -C ${WORK_DIR}/src
-(
-  cd ${WORK_DIR}/src/bison-${BISON_VERSION}/
-  ./configure --prefix=/usr/local/lib/bison-${BISON_VERSION}
-  make && make install
-  ln -s /usr/local/lib/bison-${BISON_VERSION}/bin/bison /usr/local/bin/bison
-)
-rm -rf ${WORK_DIR}
-ln -s /usr/include/x86_64-linux-gnu/curl /usr/include/curl


### PR DESCRIPTION
conchoid/docker-phpenv-builtinsで行っていた各バージョンのPreinstallを
conchoid/docker-phpenvでPreinstallするように変更。

conchoid/docker-phpenv:v1-15-7.4-stretchのタグ名でdocker hubへpushしています。

関連するPR
https://github.com/tractrix/tractrix-plugins/pull/139