### PR TITLE
V1-3-8.0 buster git lfs

### DIFF
--- a/8.0-buster/Dockerfile
+++ b/8.0-buster/Dockerfile
@@ -9,14 +9,20 @@ ENV LANGUAGE en_US:en
 ENV LC_ALL en_US.UTF-8
 
 RUN apt-get update && apt-get install -y \
-       wget curl git subversion apt-transport-https ca-certificates \
+       wget curl git subversion apt-transport-https lsb-release ca-certificates \
    && apt-get clean && rm -rf /var/lib/apt/lists/*
+
+RUN echo "deb http://ftp.debian.org/debian bullseye-backports main" > /etc/apt/sources.list.d/backports.list \
+    && apt-get update \
+    && apt-get install -y -t bullseye-backports git-lfs \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
 
 # Installing PHP 8.0
 # https://packages.sury.xyz/php/README.txt
 RUN DPKG_NAME="php8.0" \
-    && wget -O /etc/apt/trusted.gpg.d/php.gpg https://packages.sury.org/php/apt.gpg \
-    && sh -c 'echo "deb https://packages.sury.org/php/ stretch main" > /etc/apt/sources.list.d/php.list'\
+    && wget -O /usr/share/keyrings/deb.sury.org-php.gpg https://packages.sury.org/php/apt.gpg \
+    && sh -c 'echo "deb [signed-by=/usr/share/keyrings/deb.sury.org-php.gpg] https://packages.sury.org/php/ $(lsb_release -sc) main" > /etc/apt/sources.list.d/php.list' \
     && apt-get update \
     && PHP_DPKG_VERSION=$(apt-cache show "${DPKG_NAME}" | grep -e "^Version: " | cut -d" " -f2) \
     && [ -n "$PHP_DPKG_VERSION" ] \

--- a/8.0-buster/Dockerfile
+++ b/8.0-buster/Dockerfile
@@ -66,7 +66,7 @@ ENV PHPENV_ROOT /opt/phpenv
 ENV PATH "${PHPENV_ROOT}/shims:${PHPENV_ROOT}/bin:${PATH}"
 ENV ROCRO_PHP_CFLAGS "-lssl -lcrypto"
 RUN ROCRO_PHPENV_VERSION=9b7e4e1c0083c46be69f4c6d063f78c18654aad1 \
-    && PHP_BUILD_VERSION=0a1e81349dcd5044922034b76688dc7966594f5e \
+    && PHP_BUILD_VERSION=a1f569f2f62b8fad71f57953eefd2923f5ad283d \
     && git clone https://github.com/phpenv/phpenv.git ${PHPENV_ROOT} \
     && (cd ${PHPENV_ROOT} && git checkout ${ROCRO_PHPENV_VERSION}) \
     && git clone https://github.com/php-build/php-build ${PHPENV_ROOT}/plugins/php-build \
@@ -85,9 +85,10 @@ ENV PHP_AUTOCONF /usr/bin/autoconf
 # https://www.php.net/supported-versions.php
 ENV PREINSTALLED_VERSIONS "\
 7.3.33\n\
-7.4.26\n\
-8.0.13\n\
-8.1.0"
+7.4.33\n\
+8.0.26\n\
+8.1.13\n\
+8.2.0"
 
 RUN phpenv global system \
     && system_php_ver=$(php -v | head -1 | sed -e "s/^PHP \([0-9.]*\).*$/\1/") \

--- a/8.0-buster/install-builddeps.sh
+++ b/8.0-buster/install-builddeps.sh
@@ -14,10 +14,10 @@ apt-get update && apt-get -y --allow-downgrades install  \
   gnupg \
   icu-devtools="57.1-6+deb9u4" \
   libicu-dev="57.1-6+deb9u4" \
-  libssl1.1="1.1.1d-0+deb10u7" \
-  libxml2="2.9.4+dfsg1-7+deb10u2" \
-  libxml2-dev="2.9.4+dfsg1-7+deb10u2" \
-  libssl-dev="1.1.1d-0+deb10u7" \
+  libssl1.1="1.1.1n-0+deb10u3" \
+  libxml2="2.9.4+dfsg1-7+deb10u4" \
+  libxml2-dev="2.9.4+dfsg1-7+deb10u4" \
+  libssl-dev="1.1.1n-0+deb10u3" \
   libzip4="1.1.2-1.1+b1" \
   libzip-dev="1.1.2-1.1+b1" \
   sqlite3 \


### PR DESCRIPTION
phpenvにgit-lfsを追加した時にDockerBuild時に
PHP versionが更新されていたので PHP_BUILD_VERSIONを更新して対応しました。

dockerHubには書きタグでPush済みです。
conchoid/docker-phpenv:v1-3-8.0-buster

下記PRを先にマージお願いします。
https://github.com/conchoid/docker-phpenv/pull/11